### PR TITLE
Unlink symlink to dir instead of rmtree

### DIFF
--- a/src/vendoring/utils.py
+++ b/src/vendoring/utils.py
@@ -11,7 +11,7 @@ def remove_all(items_to_cleanup: Iterable[Path]) -> None:
     for item in items_to_cleanup:
         if not item.exists():
             continue
-        if item.is_dir():
+        if item.is_dir() and not item.is_symlink():
             shutil.rmtree(str(item))
         else:
             item.unlink()


### PR DESCRIPTION
If the vendoring directory contains a symlink to directory, simply unlink instead of nuking the linked directory.