### PR TITLE
Do not rewrite imports if namespace is empty

### DIFF
--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -47,6 +47,9 @@ def rewrite_file_imports(
 ) -> None:
     """Rewrite 'import xxx' and 'from xxx import' for vendored_libs.
     """
+    if namespace == "":
+        # If an empty namespace is provided, we don't rewrite imports.
+        return
 
     text = item.read_text(encoding="utf-8")
 


### PR DESCRIPTION
This is usefuly when the vendor directory is expected to be added to sys.path.