### PR TITLE
Fix sdist suffix indexing

### DIFF
--- a/src/vendoring/tasks/license.py
+++ b/src/vendoring/tasks/license.py
@@ -146,7 +146,7 @@ def extract_license_from_sdist(
                 destination, zip, zip.infolist(), license_directories,
             )
 
-    if sdist.suffixes[-2] == ".tar":
+    if sdist.suffixes[-2:-1] == [".tar"]:
         found = extract_from_source_tarfile(sdist)
     elif sdist.suffixes[-1] == ".zip":
         found = extract_from_source_zipfile(sdist)


### PR DESCRIPTION
The current check fails if the sdist has only one sdist part, such as `['.zip']`. This patch uses slices to safely get the second to last item in the list, even if the list length is less than two.