### PR TITLE
Use appdirs.user_cache_dir() as a persistent cache directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ home-page = "https://github.com/pradyunsg/vendoring"
 description-file = "README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires = [
+  "appdirs",
   "click",
   "jsonschema",
   "toml",

--- a/src/vendoring/tasks/license.py
+++ b/src/vendoring/tasks/license.py
@@ -1,9 +1,9 @@
 import tarfile
-import tempfile
 import zipfile
 from pathlib import Path
 from typing import Dict, Iterable, Union
 
+import appdirs
 import requests
 
 from vendoring.configuration import Configuration
@@ -168,10 +168,10 @@ def fetch_licenses(config: Configuration) -> None:
     license_fallback_urls = config.license_fallback_urls
     requirements = config.requirements
 
-    tmp_dir = Path(tempfile.gettempdir(), "vendoring-cache")
-    download_sdists(tmp_dir, requirements)
+    cache_dir = Path(appdirs.user_cache_dir("vendoring"))
+    download_sdists(cache_dir, requirements)
 
-    for sdist in tmp_dir.iterdir():
+    for sdist in cache_dir.iterdir():
         extract_license_from_sdist(
             destination, sdist, license_directories, license_fallback_urls
         )

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+from vendoring.tasks.license import fetch_licenses
+
+
+@mock.patch("appdirs.user_cache_dir")
+def test_user_cache_dir(mock_user_cache_dir, tmpdir):
+    cache_dir = tmpdir / "cache"
+    mock_user_cache_dir.return_value = str(cache_dir)
+    destination_dir = tmpdir / "destination"
+    destination_dir.mkdir()
+    requirements = tmpdir / "requirements.txt"
+    requirements.write_text("wheel==0.36.2\n", encoding="utf-8")
+
+    config = mock.Mock()
+    config.destination = Path(destination_dir)
+    config.requirements = Path(requirements)
+    config.license_directories = {}
+    fetch_licenses(config)
+
+    cached = os.listdir(cache_dir)
+    assert cached == ["wheel-0.36.2.tar.gz"]


### PR DESCRIPTION
Prefer using the user's cache directory over the global /tmp. If more
than one user are using the system, the global /tmp will create
permission conflicts. The user's local cache directory is more likely to
be persistent across reboots.

The user's local cache directory is still namespaced by "vendoring".

The appdirs project was introduced as a dependency for cross-platform
compatibility: https://github.com/ActiveState/appdirs