### PR TITLE
Run "nox -s lint" to align formatting with configuration

### DIFF
--- a/src/vendoring/configuration.py
+++ b/src/vendoring/configuration.py
@@ -48,8 +48,7 @@ class Configuration:
     def load_from_dict(
         cls, dictionary: Dict[str, Any], *, location: Path
     ) -> "Configuration":
-        """Constructs a Configuration, validating the values in `dictionary`, expecting paths to be within `location`.
-        """
+        """Constructs a Configuration, validating the values in `dictionary`, expecting paths to be within `location`."""
 
         schema = {
             "type": "object",

--- a/src/vendoring/errors.py
+++ b/src/vendoring/errors.py
@@ -1,13 +1,10 @@
 class VendoringError(Exception):
-    """Errors originating from this package.
-    """
+    """Errors originating from this package."""
 
 
 class ConfigurationError(VendoringError):
-    """Errors related to configuration handling.
-    """
+    """Errors related to configuration handling."""
 
 
 class RequirementsError(VendoringError):
-    """Errors related to requirements.txt handling.
-    """
+    """Errors related to requirements.txt handling."""

--- a/src/vendoring/tasks/cleanup.py
+++ b/src/vendoring/tasks/cleanup.py
@@ -25,8 +25,7 @@ def determine_items_to_remove(
 
 
 def cleanup_existing_vendored(config: Configuration) -> None:
-    """Cleans up existing vendored files in `destination` directory.
-    """
+    """Cleans up existing vendored files in `destination` directory."""
     destination = config.destination
     items = determine_items_to_remove(destination, files_to_skip=config.protected_files)
 

--- a/src/vendoring/tasks/license.py
+++ b/src/vendoring/tasks/license.py
@@ -137,13 +137,13 @@ def extract_license_from_sdist(
         ext = sdist.suffixes[-1][1:]
         with tarfile.open(sdist, mode="r:{}".format(ext)) as tar:
             return find_and_extract_license(
-                destination, tar, tar.getmembers(), license_directories,
+                destination, tar, tar.getmembers(), license_directories
             )
 
     def extract_from_source_zipfile(sdist: Path) -> bool:
         with zipfile.ZipFile(sdist) as zip:
             return find_and_extract_license(
-                destination, zip, zip.infolist(), license_directories,
+                destination, zip, zip.infolist(), license_directories
             )
 
     if sdist.suffixes[-2:-1] == [".tar"]:

--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -45,8 +45,7 @@ def rewrite_file_imports(
     vendored_libs: List[str],
     additional_substitutions: List[Dict[str, str]],
 ) -> None:
-    """Rewrite 'import xxx' and 'from xxx import' for vendored_libs.
-    """
+    """Rewrite 'import xxx' and 'from xxx import' for vendored_libs."""
     if namespace == "":
         # If an empty namespace is provided, we don't rewrite imports.
         return
@@ -65,7 +64,7 @@ def rewrite_file_imports(
             text,
         )
         text = re.sub(
-            rf"(\n\s*|^)from {lib}(\.|\s+)", rf"\1from {namespace}.{lib}\2", text,
+            rf"(\n\s*|^)from {lib}(\.|\s+)", rf"\1from {namespace}.{lib}\2", text
         )
 
     item.write_text(text, encoding="utf-8")
@@ -127,7 +126,10 @@ def vendor_libraries(config: Configuration) -> List[str]:
 
     # Rewrite the imports we want changed.
     rewrite_imports(
-        destination, config.namespace, vendored_libs, config.substitute,
+        destination,
+        config.namespace,
+        vendored_libs,
+        config.substitute,
     )
 
     # Apply user provided patches.

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -18,7 +18,7 @@ def throwaway(tmp_path):
 class TestDetermineItemsToRemove:
     def test_non_existent_directory(self, tmp_path):
         locations = determine_items_to_remove(
-            tmp_path / "non-existent", files_to_skip=[],
+            tmp_path / "non-existent", files_to_skip=[]
         )
 
         assert list(locations) == []


### PR DESCRIPTION
Currently, running "nox" reformats untouched files. To assist
contributions, re-format these files now to avoid spurious line changes
later.