### PR TITLE
Drop broken pre-commit caching from CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
-    # Cache pre-commit
-    - name: for pre-commit caching
-      run: echo "::set-env name=PY::$(python -VV | sha256sum | cut -d' ' -f1)"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-
     - uses: excitedleigh/setup-nox@0.1.0
     - run: nox


### PR DESCRIPTION
Fails with the error:

    Run echo "::set-env name=PY::$(python -VV | sha256sum | cut -d' ' -f1)"
    Python 2.7.17
    Error: Unable to process command '::set-env name=PY::e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' successfully.
    Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

After the failure, the rest of CI does not run.