### PR TITLE
Delete license tmp_dir after use

### DIFF
--- a/src/vendoring/tasks/license.py
+++ b/src/vendoring/tasks/license.py
@@ -168,10 +168,11 @@ def fetch_licenses(config: Configuration) -> None:
     license_fallback_urls = config.license_fallback_urls
     requirements = config.requirements
 
-    tmp_dir = Path(tempfile.gettempdir(), "vendoring-cache")
-    download_sdists(tmp_dir, requirements)
+    with tempfile.TemporaryDirectory(prefix="vendoring") as tmp:
+        tmp_dir = Path(tmp)
+        download_sdists(tmp_dir, requirements)
 
-    for sdist in tmp_dir.iterdir():
-        extract_license_from_sdist(
-            destination, sdist, license_directories, license_fallback_urls
-        )
+        for sdist in tmp_dir.iterdir():
+            extract_license_from_sdist(
+                destination, sdist, license_directories, license_fallback_urls
+            )

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,0 +1,29 @@
+import os
+from unittest import mock
+from pathlib import Path
+
+from vendoring.tasks.license import fetch_licenses
+
+
+def test_fetch_licesnes_multiple_times_different_packages(tmpdir):
+    tmpdir = Path(str(tmpdir))
+
+    packages = [
+        ("wheel==0.36.2", "wheel.LICENSE.txt"),
+        ("black==20.8b1", "black.LICENSE"),
+    ]
+    for i, (package, license) in enumerate(packages):
+        package_tmpdir = tmpdir / str(i)
+
+        destination_dir = package_tmpdir / "destination"
+        destination_dir.mkdir(parents=True)
+        requirements = package_tmpdir / "requirements.txt"
+        requirements.write_text(package)
+
+        config = mock.Mock()
+        config.destination = destination_dir
+        config.requirements = requirements
+        config.license_directories = {}
+        fetch_licenses(config)
+
+        assert os.listdir(destination_dir) == [license]


### PR DESCRIPTION
Avoids multiple runs from using the same set of downloaded packages to
extract licenses.

Rather than adding a new layer of caching, rely on pip caching. The
temporary directory is used for collecting packages only, not as a
cache.

Fixes #19