### PR TITLE
Allow other forms of "import lib"

### DIFF
--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -58,19 +58,22 @@ def rewrite_file_imports(
     if namespace != "":
         for lib in vendored_libs:
             text = re.sub(
-                rf"(\n\s*|^)import {lib}(\n\s*)",
+                rf"^(\s*)import {lib}(\s|$)",
                 rf"\1from {namespace} import {lib}\2",
                 text,
+                flags=re.MULTILINE,
             )
             text = re.sub(
-                rf"(\n\s*|^)import {lib}(\.\S+)(?=\s+as)",
+                rf"^(\s*)import {lib}(\.\S+)(?=\s+as)",
                 rf"\1import {namespace}.{lib}\2",
                 text,
+                flags=re.MULTILINE,
             )
             text = re.sub(
-                rf"(\n\s*|^)from {lib}(\.|\s+)",
+                rf"^(\s*)from {lib}(\.|\s)",
                 rf"\1from {namespace}.{lib}\2",
                 text,
+                flags=re.MULTILINE,
             )
 
     item.write_text(text, encoding="utf-8")

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -7,6 +7,8 @@ from vendoring.tasks.vendor import rewrite_file_imports
 _SUPPORTED_IMPORT_FORMS = textwrap.dedent(
     """\
         import other
+        import other # with comment
+        import other as somethingelse
         from other import name1
         from other.name2 import name3
         import other.name4 as name5
@@ -29,6 +31,8 @@ class TestRewriteFileImports:
         assert path.read_text() == textwrap.dedent(
             """\
                 from namespace import other
+                from namespace import other # with comment
+                from namespace import other as somethingelse
                 from namespace.other import name1
                 from namespace.other.name2 import name3
                 import namespace.other.name4 as name5
@@ -62,6 +66,8 @@ class TestRewriteFileImports:
         assert path.read_text() == textwrap.dedent(
             """\
                 from namespace import other
+                from namespace import other # with comment
+                from namespace import other as somethingelse
                 from namespace.other import NAME1
                 from namespace.other.NAME2 import NAME3
                 import namespace.other.NAME4 as NAME5
@@ -82,6 +88,8 @@ class TestRewriteFileImports:
         assert path.read_text() == textwrap.dedent(
             """\
                 import other
+                import other # with comment
+                import other as somethingelse
                 from other import NAME1
                 from other.NAME2 import NAME3
                 import other.NAME4 as NAME5


### PR DESCRIPTION
Currently both of these won't be properly vendored:

    import lib # pylint: disable=whatever-warning
    import lib as foo

Only require any whitespace after 'lib' like the other import-form
already does.

Fixes #24

---

I admit this has not been tested as well as I'd like since I cannot figure out an easy way to vendor unreleased code... Is there a trick to vendoring something from a git commit or a local dir?  I've tried various things like using `-e git://github.com/org/project.git@commithash#egg=projectname` in vendoring.txt but nothing seems to actually work (the example fails with a pip bug https://github.com/pypa/pip/issues/4390).