### PR TITLE
Fail on "import X.Y"

### DIFF
--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from vendoring.configuration import Configuration
+from vendoring.errors import VendoringError
 from vendoring.ui import UI
 from vendoring.utils import remove_all as _remove_all
 from vendoring.utils import run
@@ -57,18 +58,32 @@ def rewrite_file_imports(
     # If an empty namespace is provided, we don't rewrite imports.
     if namespace != "":
         for lib in vendored_libs:
+            # Normal case "import a"
             text = re.sub(
                 rf"^(\s*)import {lib}(\s|$)",
                 rf"\1from {namespace} import {lib}\2",
                 text,
                 flags=re.MULTILINE,
             )
+            # Special case "import a.b as b"
             text = re.sub(
                 rf"^(\s*)import {lib}(\.\S+)(?=\s+as)",
                 rf"\1import {namespace}.{lib}\2",
                 text,
                 flags=re.MULTILINE,
             )
+
+            # Error on "import a.b": this cannot be rewritten
+            # (except for the special case handled above)
+            match = re.search(
+                rf"^\s*(import {lib}\.\S+)",
+                text,
+                flags=re.MULTILINE,
+            )
+            if match:
+                raise VendoringError(f"Cannot rewrite '{match.group(1)}' in {item}")
+
+            # Normal case "from a import b"
             text = re.sub(
                 rf"^(\s*)from {lib}(\.|\s)",
                 rf"\1from {namespace}.{lib}\2",


### PR DESCRIPTION
Vendoring is impossible if the style

    import X.Y

is used in upstream source. Fail loudly in this case.

--- 

This fixes #15 but you might still not want to merge: vendoring pip will currently errors out with 
```
VendoringError: Cannot rewrite 'import urllib3.contrib.securetransport' in src/pip/_vendor/urllib3/contrib/securetransport.py
```
which is a valid complaint... except that the code in question happens to be in a docstring.

I think I'm not going to work on this further -- if you'd rather not have this PR but just a comment in the issue let me know.