### PR TITLE
fix: Windows double line spacing fix

### DIFF
--- a/src/vendoring/tasks/update.py
+++ b/src/vendoring/tasks/update.py
@@ -3,7 +3,6 @@
 
 import re
 from dataclasses import dataclass
-from os import linesep
 from pathlib import Path
 from typing import List, Optional
 
@@ -85,4 +84,4 @@ def update_requirements(config: Configuration, package: Optional[str]) -> None:
 
     UI.log(f"Rewriting {requirements}")
     with requirements.open("w", encoding="utf-8") as f:
-        f.writelines(f"{p}{linesep}" for p in packages)
+        f.writelines(f"{p}\n" for p in packages)


### PR DESCRIPTION
The current version does not work on Windows, as reported by @pfmoore in https://github.com/pypa/pip/issues/9462. Files opened in text mode should not have the native line ending applied - Python normalizes this for you. Quick demo of problem:

```python
from pathlib import Path
from os import linesep

txt = Path("tmp.txt")
with txt.open("w", encoding="utf-8") as f:
    f.writelines(f"{p}{linesep}" for p in range(3))
with txt.open(encoding="utf-8") as f:
    print(f.read())
```

This produces empty lines between outputs, but only Windows (due to the separator there).

Had to find and boot up an old Windows box to verify that demo. :angry: