### PR TITLE
ci: fix removed syntax for GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
 
     # Cache pre-commit
     - name: for pre-commit caching
-      run: echo "::set-env name=PY::$(python -VV | sha256sum | cut -d' ' -f1)"
+      run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" > $GITHUB_ENV
+      shell: bash
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
-    - uses: excitedleigh/setup-nox@0.1.0
-    - run: nox
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - run: pipx run nox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,6 @@
 repos:
-
-  - repo: https://github.com/psf/black
-    rev: stable
-    hooks:
-      - id: black
-        language_version: python3.8
-
-  - repo: https://github.com/timothycrosley/isort
-    rev: '4.3.21-2'
-    hooks:
-      - id: isort
-        files: \.py$
-        args: ["--settings-path", ".isort.cfg"]
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.740'
-    hooks:
-      - id: mypy
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v2.4.0'
+    rev: v3.4.0
     hooks:
       - id: check-builtin-literals
       - id: check-added-large-files
@@ -28,6 +9,28 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
-      - id: flake8
       - id: forbid-new-submodules
       - id: trailing-whitespace
+
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3.8
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.7.0
+    hooks:
+      - id: isort
+        files: \.py$
+        args: ["--settings-path", ".isort.cfg"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.800
+    hooks:
+      - id: mypy
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8

--- a/src/vendoring/configuration.py
+++ b/src/vendoring/configuration.py
@@ -48,8 +48,7 @@ class Configuration:
     def load_from_dict(
         cls, dictionary: Dict[str, Any], *, location: Path
     ) -> "Configuration":
-        """Constructs a Configuration, validating the values in `dictionary`, expecting paths to be within `location`.
-        """
+        """Constructs a Configuration, validating the values in `dictionary`, expecting paths to be within `location`."""
 
         schema = {
             "type": "object",

--- a/src/vendoring/errors.py
+++ b/src/vendoring/errors.py
@@ -1,13 +1,10 @@
 class VendoringError(Exception):
-    """Errors originating from this package.
-    """
+    """Errors originating from this package."""
 
 
 class ConfigurationError(VendoringError):
-    """Errors related to configuration handling.
-    """
+    """Errors related to configuration handling."""
 
 
 class RequirementsError(VendoringError):
-    """Errors related to requirements.txt handling.
-    """
+    """Errors related to requirements.txt handling."""

--- a/src/vendoring/tasks/cleanup.py
+++ b/src/vendoring/tasks/cleanup.py
@@ -25,8 +25,7 @@ def determine_items_to_remove(
 
 
 def cleanup_existing_vendored(config: Configuration) -> None:
-    """Cleans up existing vendored files in `destination` directory.
-    """
+    """Cleans up existing vendored files in `destination` directory."""
     destination = config.destination
     items = determine_items_to_remove(destination, files_to_skip=config.protected_files)
 

--- a/src/vendoring/tasks/license.py
+++ b/src/vendoring/tasks/license.py
@@ -137,13 +137,19 @@ def extract_license_from_sdist(
         ext = sdist.suffixes[-1][1:]
         with tarfile.open(sdist, mode="r:{}".format(ext)) as tar:
             return find_and_extract_license(
-                destination, tar, tar.getmembers(), license_directories,
+                destination,
+                tar,
+                tar.getmembers(),
+                license_directories,
             )
 
     def extract_from_source_zipfile(sdist: Path) -> bool:
         with zipfile.ZipFile(sdist) as zip:
             return find_and_extract_license(
-                destination, zip, zip.infolist(), license_directories,
+                destination,
+                zip,
+                zip.infolist(),
+                license_directories,
             )
 
     if sdist.suffixes[-2:-1] == [".tar"]:

--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -45,8 +45,7 @@ def rewrite_file_imports(
     vendored_libs: List[str],
     additional_substitutions: List[Dict[str, str]],
 ) -> None:
-    """Rewrite 'import xxx' and 'from xxx import' for vendored_libs.
-    """
+    """Rewrite 'import xxx' and 'from xxx import' for vendored_libs."""
     if namespace == "":
         # If an empty namespace is provided, we don't rewrite imports.
         return
@@ -65,7 +64,9 @@ def rewrite_file_imports(
             text,
         )
         text = re.sub(
-            rf"(\n\s*|^)from {lib}(\.|\s+)", rf"\1from {namespace}.{lib}\2", text,
+            rf"(\n\s*|^)from {lib}(\.|\s+)",
+            rf"\1from {namespace}.{lib}\2",
+            text,
         )
 
     item.write_text(text, encoding="utf-8")
@@ -127,7 +128,10 @@ def vendor_libraries(config: Configuration) -> List[str]:
 
     # Rewrite the imports we want changed.
     rewrite_imports(
-        destination, config.namespace, vendored_libs, config.substitute,
+        destination,
+        config.namespace,
+        vendored_libs,
+        config.substitute,
     )
 
     # Apply user provided patches.

--- a/src/vendoring/utils.py
+++ b/src/vendoring/utils.py
@@ -30,11 +30,12 @@ def run(command: List[str], *, working_directory: Optional[Path]) -> None:
     )
     while True:
         retcode = p.poll()
-        line = p.stdout.readline().rstrip()
+        if p.stdout is not None:
+            line = p.stdout.readline().rstrip()
 
-        if line:
-            with UI.indent():
-                UI.log(line)
+            if line:
+                with UI.indent():
+                    UI.log(line)
 
         if retcode is not None:
             break

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -18,7 +18,8 @@ def throwaway(tmp_path):
 class TestDetermineItemsToRemove:
     def test_non_existent_directory(self, tmp_path):
         locations = determine_items_to_remove(
-            tmp_path / "non-existent", files_to_skip=[],
+            tmp_path / "non-existent",
+            files_to_skip=[],
         )
 
         assert list(locations) == []


### PR DESCRIPTION
Actions replaced this due to a security venerability: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Should fix CI issue in #27 

Closes #22.