### PR TITLE
Skip stub generation if there's a py.typed

### DIFF
--- a/src/vendoring/tasks/stubs.py
+++ b/src/vendoring/tasks/stubs.py
@@ -46,5 +46,7 @@ def generate_stubs(config: Configuration, libraries: List[str]) -> None:
 
     for lib in libraries:
         for rel_location, import_name in determine_stub_files(lib, typing_stubs):
+            if (destination / lib / "py.typed").is_file():  # Already have types.
+                continue
             stub_location = destination / rel_location
             write_stub(stub_location, import_name)

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -36,10 +36,7 @@ def test_basic(tmp_path, monkeypatch):
 
     vendored = tmp_path / "vendored"
     assert vendored.exists()
-    assert sorted(os.listdir(vendored)) == [
-        "packaging",
-        "packaging.pyi",
-    ]
+    assert sorted(os.listdir(vendored)) == ["packaging"]
 
     packaging = vendored / "packaging"
     assert packaging.exists()
@@ -140,11 +137,7 @@ def test_protected_files(tmp_path, monkeypatch):
 
     vendored = tmp_path / "vendored"
     assert vendored.exists()
-    assert sorted(os.listdir(vendored)) == [
-        "README.md",
-        "packaging",
-        "packaging.pyi",
-    ]
+    assert sorted(os.listdir(vendored)) == ["README.md", "packaging"]
 
 
 def test_transformations(tmp_path, monkeypatch):


### PR DESCRIPTION
Fix #31 (I think)