### PR TITLE
Explicitly support implicit build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "toml",
   "requests",
   "packaging",
+  "pip",
 ]
 requires-python = "~= 3.8"
 readme = "README.md"

--- a/src/vendoring/tasks/license.py
+++ b/src/vendoring/tasks/license.py
@@ -140,6 +140,7 @@ def download_distributions(location: Path, requirements: Path) -> None:
         "-m",
         "pip",
         "download",
+        "--use-pep517",
         "-r",
         str(requirements),
         "--no-deps",

--- a/src/vendoring/tasks/license.py
+++ b/src/vendoring/tasks/license.py
@@ -1,4 +1,5 @@
 import shutil
+import sys
 import tarfile
 import tempfile
 import zipfile
@@ -135,6 +136,8 @@ class LicenseExtractor:
 
 def download_distributions(location: Path, requirements: Path) -> None:
     cmd = [
+        sys.executable,
+        "-m",
         "pip",
         "download",
         "-r",

--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -20,6 +20,7 @@ def download_libraries(requirements: Path, destination: Path) -> None:
         "-m",
         "pip",
         "install",
+        "--use-pep517",
         "-t",
         str(destination),
         "-r",

--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -2,6 +2,7 @@
 """
 
 import re
+import sys
 from pathlib import Path
 from typing import Dict, List
 
@@ -15,6 +16,8 @@ from vendoring.utils import run
 
 def download_libraries(requirements: Path, destination: Path) -> None:
     command = [
+        sys.executable,
+        "-m",
         "pip",
         "install",
         "-t",


### PR DESCRIPTION
This change uses the `--use-pep517` flag in a parameter to pip to ensure that any projects that implicitly require Setuptools will get it, removing the implicit dependency on setuptools in the user's environment.

Additionally, explicitly declares the dependency on pip and invokes it from the environment where vendoring is installed rather than relying on the user to have pip installed somewhere in their system path.

Fixes the issue reported in #39.

```
setuptools feature/vendoring $ pip-run -q git+https://github.com/jaraco/vendoring@bugfix/39-explicit-build-deps -- -m vendoring sync
Working in .
Load configuration... Done!
Clean existing libraries... Done!
Add vendored libraries... Done!
Fetch licenses... Done!
Generate static-typing stubs... Done!
```