### PR TITLE
Replace toml dependency with tomli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,10 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - click
           - nox
           - pytest
           - types-requests
-          - types-toml
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "click",
   "rich",
   "jsonschema",
-  "toml",
+  "tomli",
   "requests",
   "packaging",
 ]

--- a/src/vendoring/configuration.py
+++ b/src/vendoring/configuration.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from jsonschema import ValidationError, validate
-from toml import TomlDecodeError
-from toml import loads as parse_toml
+from tomli import TOMLDecodeError
+from tomli import loads as parse_toml
 
 from vendoring.errors import ConfigurationError
 from vendoring.ui import UI
@@ -143,7 +143,7 @@ def load_configuration(directory: Path) -> Configuration:
 
     try:
         parsed_contents = parse_toml(file_contents)
-    except TomlDecodeError as toml_error:
+    except TOMLDecodeError as toml_error:
         raise ConfigurationError("Could not parse pyproject.toml.") from toml_error
     else:
         UI.log("Parsed configuration file.")


### PR DESCRIPTION
Python 3.11 introduces tomllib which originated as tomli. Standardized
on blessed stlib package for forward compatibility and allow for
eventually dropping the dependency in the future.

https://docs.python.org/3.11/library/tomllib.html

tomli is also the package used by pip.