### PR TITLE
Set platform to any when running pip install

### DIFF
--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -17,6 +17,8 @@ def download_libraries(requirements: Path, destination: Path) -> None:
     command = [
         "pip",
         "install",
+        "--platform",
+        "any",
         "-t",
         str(destination),
         "-r",


### PR DESCRIPTION
We want to vendor only Python-only distributions.