### PR TITLE
Add click package to mypy environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - click
           - nox
           - pytest
           - types-requests


### PR DESCRIPTION
Fixes the errors:

    src/vendoring/cli.py:40: error: Untyped decorator makes function "main" untyped
     [misc]
        @click.group()
         ^
    src/vendoring/cli.py:45: error: Untyped decorator makes function "sync" untyped
     [misc]
        @main.command()
         ^
    src/vendoring/cli.py:77: error: Untyped decorator makes function "update"
    untyped  [misc]
        @main.command()
         ^
    Found 3 errors in 1 file (checked 18 source files)