### PR TITLE
Add a `preserve_metadata` option

### DIFF
--- a/src/vendoring/configuration.py
+++ b/src/vendoring/configuration.py
@@ -36,6 +36,9 @@ class Configuration:
     # Drop
     drop_paths: List[str]
 
+    # Preserve package metadata
+    preserve_metadata: bool
+
     # Fallbacks for licenses that can't be found
     license_fallback_urls: Dict[str, str]
     # Alternate directory name, when distribution name differs from the package name
@@ -60,6 +63,7 @@ class Configuration:
                 "requirements": {"type": "string"},
                 "protected-files": {"type": "array", "items": {"type": "string"}},
                 "patches-dir": {"type": "string"},
+                "preserve_metadata": {"type": "boolean"},
                 "transformations": {
                     "type": "object",
                     "additionalProperties": False,
@@ -121,6 +125,7 @@ class Configuration:
             patches_dir=path_or_none("patches-dir"),
             substitute=dictionary.get("transformations", {}).get("substitute", {}),
             drop_paths=dictionary.get("transformations", {}).get("drop", []),
+            preserve_metadata=dictionary.get("preserve_metadata", False),
             license_fallback_urls=dictionary.get("license", {}).get(
                 "fallback-urls", {}
             ),

--- a/src/vendoring/tasks/vendor.py
+++ b/src/vendoring/tasks/vendor.py
@@ -35,7 +35,14 @@ def _looks_like_glob(pattern: str) -> bool:
     return "*" in pattern or "?" in pattern or "[" in pattern
 
 
-def remove_unnecessary_items(destination: Path, drop_paths: List[str]) -> None:
+def remove_unnecessary_items(
+    destination: Path, drop_paths: List[str], preserve_metadata: bool
+) -> None:
+    # Cleanup any metadata directories created.
+    if not preserve_metadata:
+        _remove_all(destination.glob("*.dist-info"))
+        _remove_all(destination.glob("*.egg-info"))
+
     for pattern in drop_paths:
         if pattern.startswith("^"):
             _remove_matching_regex(destination, pattern)
@@ -158,7 +165,7 @@ def vendor_libraries(config: Configuration) -> List[str]:
     download_libraries(config.requirements, destination)
 
     # Cleanup unnecessary directories/files created.
-    remove_unnecessary_items(destination, config.drop_paths)
+    remove_unnecessary_items(destination, config.drop_paths, config.preserve_metadata)
 
     # Detect what got downloaded.
     vendored_libs = detect_vendored_libs(destination, config.protected_files)


### PR DESCRIPTION
This change adds `preserve_metdata` boolean flag in config, which defaults to
False. If set to True, then the vendor task will *not* remove `.dist-info` and
`.egg-info` files.

The motivation is that some libraries use `pkg_resources` or
`importlib.metadata` to inspect locally installed packages, e.g for plugin
loading. Previously, the metadata needed for those APIs was deleted.

This change allows a user to preserve the metadata in the vendoring directory
if they want to.  They will still need to add that dir to sys.path for it to
work, but at least they have the option to do that now.
