### PR TITLE
Drop upper bound in `python-requires`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "requests",
   "packaging",
 ]
-requires-python = "~= 3.8"
+requires-python = ">= 3.8"
 readme = "README.md"
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
Proposal to drop the upper bound in `python-requires` (cf https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#requires-python-upper-bounds)