### PR TITLE
Move to test on / use Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
 
   tests:
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.11"
       - run: pip install nox
       - run: nox -s test -- -vvv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python3.11
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ import nox
 nox.options.sessions = ["lint", "test"]
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.11")
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")
 
@@ -22,7 +22,7 @@ def lint(session: nox.Session) -> None:
     session.run("pre-commit", "run", *args)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.11")
 def test(session: nox.Session) -> None:
     session.install(".[test]")
     session.run("pytest", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "requests",
   "packaging",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.11"
 readme = "README.md"
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
This change is largely in preparation for a move to tomllib.

It is intentionally bare-bones to make it (hopefully!) easy to review. :)

resolves #71
